### PR TITLE
Fix `aha follow` grep regex

### DIFF
--- a/ahab.sh
+++ b/ahab.sh
@@ -44,7 +44,7 @@ case $1 in
 		echo -e "I'll chase him round Good Hope,\nand round the Horn,\nand round the Norway Maelstrom,\nand round perdition's flames before I give him up.\n"
 		shift
 		image=$1
-		until containers=`docker ps | tail -n +2 | grep $image | grep -o "[0-9a-f]\{12\}"`; do
+		until containers=`docker ps | tail -n +2 | grep $image | grep -o "^[0-9a-f]\{12\}"`; do
 			:
 		done
 		container=`echo $containers | head -n 1`


### PR DESCRIPTION
The old regex had problems with some registries (such as the amazon docker registry). This fixes that.