### PR TITLE
Feature/continuous follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Commands
   This command needs to be followed by the machine name if you are using docker-machine
   (you probably want to use the `--engine-insecure-registry` option when creating the machine, though).
 * `follow <image_name> <other flags to be passed>`:
-  Search for container by image name and show its logs, like `docker logs -f <container>`
+  Search for container by image name and follow its logs, like `docker logs -f <container>`.
+  If the container dies, follow searches for the container again. Hit CTRL-C to stop.
   (eg. `./ahab.sh follow elasticsearch -t`). It blocks until there is at least one container running that image.
 * `execute <image_name> <other flags to be passed>`: Search for an image and launch a container
   (eg. `./ahab.sh execute elastic -p 9200:9200`).

--- a/ahab.sh
+++ b/ahab.sh
@@ -29,22 +29,22 @@ function trust_registry {
 }
 
 function log_follow {
-    local ended_once=false
-    local image=$1
-    shift
-    local args=$*
-    while :
-    do
-	    until containers=`docker ps | tail -n +2 | grep $image | grep -o "^[0-9a-f]\{12\}"`; do
-		    sleep 0.5
+	local ended_once=false
+	local image=$1
+	shift
+	local args=$*
+	while :
+	do
+		until containers=`docker ps | tail -n +2 | grep $image | grep -o "^[0-9a-f]\{12\}"`; do
+			sleep 0.5
 		done
-        if [ "$ended_once" = true ] ; then
-            echo -e "\n==> New container found. Following logs now. <==\n"
-        fi
+		if [ "$ended_once" = true ] ; then
+			echo -e "\n==> New container found. Following logs now. <==\n"
+		fi
 		container=`echo $containers | head -n 1`
 		docker logs -f $args $container
-        ended_once=true
-    done
+		ended_once=true
+	done
 }
 
 case $1 in
@@ -62,7 +62,7 @@ case $1 in
 	follow)
 		echo -e "I'll chase him round Good Hope,\nand round the Horn,\nand round the Norway Maelstrom,\nand round perdition's flames before I give him up.\n"
 		shift
-        log_follow $*
+		log_follow $*
 	;;
 	execute)
 		echo -e "Imagine if you must,\na whale in a bust,\nname it you might\nas it is alive and white!\n"

--- a/ahab.sh
+++ b/ahab.sh
@@ -28,6 +28,25 @@ function trust_registry {
 	fi
 }
 
+function log_follow {
+    local ended_once=false
+    local image=$1
+    shift
+    local args=$*
+    while :
+    do
+	    until containers=`docker ps | tail -n +2 | grep $image | grep -o "^[0-9a-f]\{12\}"`; do
+		    sleep 0.5
+		done
+        if [ "$ended_once" = true ] ; then
+            echo -e "\n==> New container found. Following logs now. <==\n"
+        fi
+		container=`echo $containers | head -n 1`
+		docker logs -f $args $container
+        ended_once=true
+    done
+}
+
 case $1 in
 	sail)
 		echo -e "Naught’s an obstacle,\nnaught’s an angle to the iron way!\n"
@@ -43,13 +62,7 @@ case $1 in
 	follow)
 		echo -e "I'll chase him round Good Hope,\nand round the Horn,\nand round the Norway Maelstrom,\nand round perdition's flames before I give him up.\n"
 		shift
-		image=$1
-		until containers=`docker ps | tail -n +2 | grep $image | grep -o "^[0-9a-f]\{12\}"`; do
-			:
-		done
-		container=`echo $containers | head -n 1`
-		shift
-		docker logs -f $* $container
+        log_follow $*
 	;;
 	execute)
 		echo -e "Imagine if you must,\na whale in a bust,\nname it you might\nas it is alive and white!\n"


### PR DESCRIPTION
This changes the behavior of `follow` action: it now works in an endless loop of image search and `docker logs`. One must hit `CTRL-C` to stop.

 This seems nicer in most use cases, and more in line with a "follow" action.